### PR TITLE
[Feat] 포켓몬 도메인 모델 구현

### DIFF
--- a/Pokedex/Pokedex/Models/Domain/Pokemon.swift
+++ b/Pokedex/Pokedex/Models/Domain/Pokemon.swift
@@ -1,0 +1,27 @@
+//
+//  Pokemon.swift
+//  Pokedex
+//
+//  Created by Jamong on 1/5/25.
+//
+
+import Foundation
+
+/// 포켓몬의 기본 정보를 담는 모델
+struct Pokemon {
+    /// 포켓몬 도감 번호
+    let id: Int
+    /// 포켓몬 영문 이름
+    let name: String
+    /// 포켓몬 한글 이름
+    let koreanName: String
+    /// 포켓몬 이미지 URL
+    let imageUrl: URL?
+    
+    /// 표시할 이름 (한글이 있으면 한글, 없으면 영문)
+    var displayName: String {
+        koreanName.isEmpty ? name.capitalized : koreanName
+    }
+}
+
+

--- a/Pokedex/Pokedex/Models/Domain/PokemonDetail.swift
+++ b/Pokedex/Pokedex/Models/Domain/PokemonDetail.swift
@@ -1,0 +1,47 @@
+//
+//  PokemonDetail.swift
+//  Pokedex
+//
+//  Created by Jamong on 1/5/25.
+//
+
+import Foundation
+
+
+/// 포켓몬의 상세 정보를 담는 모델
+struct PokemonDetail {
+    /// 포켓몬 도감 번호
+    let id: Int
+    /// 포켓몬 영문 이름
+    let name: String
+    /// 포켓몬 한글 이름
+    let koreanName: String
+    /// 포켓몬 이미지 URL
+    let imageURL: URL?
+    /// 포켓몬 키(m)
+    let height: Double
+    /// 포켓몬 몸무게(Kg)
+    let weight: Double
+    /// 포켓몬 타입 목록
+    let types: [PokemonType]
+    
+    /// 표시할 이름 (한글이 있으면 한글, 없으면 영문)
+    var displayName: String {
+        koreanName.isEmpty ? name.capitalized : koreanName
+    }
+    
+    /// 표시할 키
+    var displayHeight: String {
+        String(format: "%.1f m", height)
+    }
+    
+    /// 표시할 몸무게
+    var displayWeight: String {
+        String(format: "%.1f Kg", weight)
+    }
+    
+    /// 포켓몬의 메인 타입
+    var mainType: PokemonType? {
+        types.first
+    }
+}

--- a/Pokedex/Pokedex/Models/Domain/PokemonType.swift
+++ b/Pokedex/Pokedex/Models/Domain/PokemonType.swift
@@ -1,0 +1,78 @@
+//
+//  PokemonType.swift
+//  Pokedex
+//
+//  Created by Jamong on 1/5/25.
+//
+
+import Foundation
+
+/// 포켓몬의 타입을 정의하는 열거형
+enum PokemonType: String {
+    case normal
+    case fire
+    case water
+    case electric
+    case grass
+    case ice
+    case fighting
+    case poison
+    case ground
+    case flying
+    case psychic
+    case bug
+    case rock
+    case ghost
+    case dragon
+    case dark
+    case steel
+    case fairy
+    
+    /// 타입의 한글 이름
+    var localizedName: String {
+        switch self {
+        case .normal: return "노말"
+        case .fire: return "불꽃"
+        case .water: return "물"
+        case .electric: return "전기"
+        case .grass: return "풀"
+        case .ice: return "얼음"
+        case .fighting: return "격투"
+        case .poison: return "독"
+        case .ground: return "땅"
+        case .flying: return "비행"
+        case .psychic: return "에스퍼"
+        case .bug: return "벌레"
+        case .rock: return "바위"
+        case .ghost: return "고스트"
+        case .dragon: return "드래곤"
+        case .dark: return "악"
+        case .steel: return "강철"
+        case .fairy: return "페어리"
+        }
+    }
+    
+    /// 타입의 대표 색상 (HEX 코드)
+    var color: String {
+        switch self {
+        case .normal: return "#A8A878"
+        case .fire: return "#F08030"
+        case .water: return "#6890F0"
+        case .electric: return "#F8D030"
+        case .grass: return "#78C850"
+        case .ice: return "#98D8D8"
+        case .fighting: return "#C03028"
+        case .poison: return "#A040A0"
+        case .ground: return "#E0C068"
+        case .flying: return "#A890F0"
+        case .psychic: return "#F85888"
+        case .bug: return "#A8B820"
+        case .rock: return "#B8A038"
+        case .ghost: return "#705898"
+        case .dragon: return "#7038F8"
+        case .dark: return "#705848"
+        case .steel: return "#B8B8D0"
+        case .fairy: return "#EE99AC"
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용
### 1. 포켓몬 기본 모델
- Pokemon (기본 모델)
- PokemonDetail (디테일 화면 모델)
- PokemonType (타입 모델)

### 구현 내용
1. Pokemon (기본 모델)
   - 기본 정보(도감번호, 이름, 이미지URL) 포함
   - 한글/영문 이름 처리 구현
   - 표시용 이름 계산 프로퍼티 구현

2. PokemonDetail (디테일 화면 모델)
   - Pokemon 기본 정보 확장
   - 신체 정보(키, 몸무게) 추가
   - 타입 정보 추가
   - 표시용 프로퍼티 구현

3. PokemonType (타입 모델)
   - 18가지 포켓몬 타입 정의
   - 한글 이름 매핑
   - 타입별 색상 정의

## 📋 관련 이슈
- Closes #3 