### PR TITLE
✨[Feat] ViewModel  레이어 구현

### DIFF
--- a/Pokedex/Pokedex/Models/Domain/PokemonDetail.swift
+++ b/Pokedex/Pokedex/Models/Domain/PokemonDetail.swift
@@ -23,7 +23,7 @@ struct PokemonDetail {
     /// 포켓몬 몸무게(Kg)
     let weight: Double
     /// 포켓몬 타입 목록
-    let types: [PokemonType]
+    let mainType: PokemonType?
     
     /// 표시할 이름 (한글이 있으면 한글, 없으면 영문)
     var displayName: String {
@@ -38,10 +38,5 @@ struct PokemonDetail {
     /// 표시할 몸무게
     var displayWeight: String {
         String(format: "%.1f Kg", weight)
-    }
-    
-    /// 포켓몬의 메인 타입
-    var mainType: PokemonType? {
-        types.first
     }
 }

--- a/Pokedex/Pokedex/ViewModel/DetailViewModel.swift
+++ b/Pokedex/Pokedex/ViewModel/DetailViewModel.swift
@@ -1,0 +1,84 @@
+//
+//  DetailViewModel.swift
+//  Pokedex
+//
+//  Created by Jamong on 1/5/25.
+//
+
+import Foundation
+import RxSwift
+
+
+class DetailViewModel {
+    // MARK: - Properties
+    
+    /// 구독 해제를 위한 DisposeBag
+    private let disposeBag = DisposeBag()
+    /// 선택된 포켓몬 ID
+    private let pokemonId: Int
+    
+    // MARK: - Subjects
+    
+    /// View가 구독할 Subjects
+    let pokemonSubject = BehaviorSubject<PokemonDetail?>(value: nil)
+    let loadingSubject = BehaviorSubject<Bool>(value: false)
+    let errorSubject = PublishSubject<Error>()
+    
+    // MARK: - Initialization
+    
+    init(pokemonId: Int) {
+        self.pokemonId = pokemonId
+        fetchPokemonDetail()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// 포켓몬 상세 정보를 다시 불러옴
+    func refresh() {
+        fetchPokemonDetail()
+    }
+    
+    /// 포켓몬 상세 정보를 불러오는 함수
+    private func fetchPokemonDetail() {
+        // 로딩 시작
+        loadingSubject.onNext(true)
+        
+        // URL 생성
+        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon/\(pokemonId)") else {
+            errorSubject.onNext(NetworkError.invalidUrl)
+            return
+        }
+        
+        // 네트워크 요청
+        NetworkManager.shared.fetch(url: url)
+            .subscribe(onSuccess: { [weak self] (response: PokemonDetailResponse) in
+                // 포켓몬 모델로 변환
+                guard let imageUrl = URL(string: response.imageUrl) else {
+                    self?.errorSubject.onNext(NetworkError.invalidUrl)
+                    return
+                }
+                
+                let mainType = PokemonType(rawValue: response.mainType)
+                
+                let detail = PokemonDetail(
+                    id: response.id,
+                    name: response.name,
+                    koreanName: "",
+                    imageURL: imageUrl,
+                    height: response.heightInMeters,
+                    weight: response.weightInKg,
+                    mainType: mainType
+                )
+                
+                // 데이터 전달
+                self?.pokemonSubject.onNext(detail)
+                self?.loadingSubject.onNext(false)
+            }, onFailure: { [weak self] error in
+                // 에러 전달
+                self?.errorSubject.onNext(error)
+                self?.loadingSubject.onNext(false)
+            })
+            .disposed(by: disposeBag)
+    }
+}
+

--- a/Pokedex/Pokedex/ViewModel/MainViewModel.swift
+++ b/Pokedex/Pokedex/ViewModel/MainViewModel.swift
@@ -1,0 +1,101 @@
+//
+//  MainViewModel.swift
+//  Pokedex
+//
+//  Created by Jamong on 1/5/25.
+//
+
+import Foundation
+import RxSwift
+
+/// 메인 화면의 포켓몬 목록을 관리하는 ViewModel
+class MainViewModel {
+    // MARK: - Properties
+    
+    /// 구독 해제를 위한 DisposeBag
+    private let disposeBag = DisposeBag()
+    
+    // MARK: - Subjects
+    
+    /// View가 구독할 Subjects
+    let pokemonListSubject = BehaviorSubject<[Pokemon]>(value: [])
+    let loadingSubject = BehaviorSubject<Bool>(value: false)
+    let errorSubject = PublishSubject<Error>()
+    
+    // MARK: - Pagination Properties
+    
+    /// 페이지 정보
+    private var currentPage = 0
+    private let itemsPerPage = 20
+    
+    // MARK: - Initialization
+    
+    init() {
+        fetchPokemonList()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// 포켓몬 리스트를 처음부터 다시 불러옴
+    func refresh() {
+        currentPage = 0
+        fetchPokemonList()
+    }
+    
+    
+    /// 다음 페이지 포켓몬 리스트를 불러옴
+    func fetchNextPage() {
+        currentPage += 1
+        fetchPokemonList()
+    }
+    
+    // MARK: - Private Methods
+    
+    /// 포켓몬 리스트 데이터를 불러오는 함수
+    private func fetchPokemonList() {
+        /// 로딩 시작하기
+        loadingSubject.onNext(true)
+        
+        /// URL 생성
+        let offset = currentPage * itemsPerPage
+        guard let url = URL(string: "https://pokeapi.co/api/v2/pokemon?offset=\(offset)&limit=\(itemsPerPage)") else {
+            errorSubject.onNext(NetworkError.invalidUrl)
+            return
+        }
+        
+        /// 네트워크 요청
+        NetworkManager.shared.fetch(url: url)
+            .subscribe(onSuccess: { [weak self] (response: PokemonListResponse) in
+                // 포켓몬 모델로 변환
+                let pokemons = response.results.compactMap { item -> Pokemon? in
+                    guard let id = item.id,
+                          let imageUrlString = item.imageUrl,
+                          let imageUrl = URL(string: imageUrlString) else {
+                        return nil
+                    }
+                    
+                    return Pokemon(
+                        id: id,
+                        name: item.name,
+                        koreanName: "",
+                        imageUrl: imageUrl
+                    )
+                }
+                
+                // 현재 리스트에 추가
+                if let currentPokemons = try? self?.pokemonListSubject.value() {
+                    self?.pokemonListSubject.onNext(currentPokemons + pokemons)
+                } else {
+                    self?.pokemonListSubject.onNext(pokemons)
+                }
+                
+                // 로딩 완료
+                self?.loadingSubject.onNext(false)
+            }, onFailure: { [weak self] error in
+                // 에러 전달
+                self?.errorSubject.onNext(error)
+                self?.loadingSubject.onNext(false)
+            })
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 📝 PR 내용
### ViewModel 레이어 구현
- MainViewModel
- DetailViewModel

## 구현 내용

### 1. MainViewModel
- 포켓몬 목록 데이터 관리
- 페이지 단위 데이터 로딩 (20개씩)
- 새로고침 및 추가 로딩 기능
- 로딩/에러 상태 처리

### 2. DetailViewModel
- 포켓몬 상세 정보 조회
- API 응답 데이터를 도메인 모델로 변환
- 메인 타입만 사용하도록 최적화
- 로딩/에러 상태 처리

## 📋 관련 이슈
- Closes #4 